### PR TITLE
Add a PlatformSpecific annotation to limit commands and configuration nodes to specific platforms

### DIFF
--- a/core/src/main/java/dev/triassic/template/TemplateImpl.java
+++ b/core/src/main/java/dev/triassic/template/TemplateImpl.java
@@ -9,6 +9,7 @@
 
 package dev.triassic.template;
 
+import dev.triassic.template.annotation.PlatformSpecific;
 import dev.triassic.template.command.CommandRegistry;
 import dev.triassic.template.command.Commander;
 import dev.triassic.template.configuration.ConfigurationManager;
@@ -49,18 +50,20 @@ public final class TemplateImpl {
     /**
      * Called when the bootstrapped plugin is done initializing.
      */
+    @PlatformSpecific(PlatformType.BUKKIT)
     public void initialize() {
         final long startTime = System.currentTimeMillis();
 
         try {
-            this.config = ConfigurationManager.load(dataDirectory, TemplateConfiguration.class);
+            this.config = ConfigurationManager.load(
+                dataDirectory, TemplateConfiguration.class, platformType);
         } catch (IOException e) {
             logger.error("Failed to load configuration", e);
             return;
         }
 
         this.commandRegistry = new CommandRegistry(this, commandManager);
-        commandRegistry.registerAll();
+        commandRegistry.registerAll(platformType);
 
         logger.info("Enabled in {}ms", System.currentTimeMillis() - startTime);
     }

--- a/core/src/main/java/dev/triassic/template/annotation/PlatformSpecific.java
+++ b/core/src/main/java/dev/triassic/template/annotation/PlatformSpecific.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: CC0-1.0
+ *
+ * Dedicated to the public domain under CC0 1.0 Universal.
+ *
+ * You can obtain a full copy of the license at:
+ *     https://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package dev.triassic.template.annotation;
+
+import dev.triassic.template.util.PlatformType;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a class, method, or field as being specific to one or more platforms.
+ * Can be used for runtime checks or documentation.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
+public @interface PlatformSpecific {
+
+    /**
+     * The platforms this class/method/field is intended for.
+     */
+    PlatformType[] value();
+}

--- a/core/src/main/java/dev/triassic/template/command/CommandRegistry.java
+++ b/core/src/main/java/dev/triassic/template/command/CommandRegistry.java
@@ -10,7 +10,9 @@
 package dev.triassic.template.command;
 
 import dev.triassic.template.TemplateImpl;
+import dev.triassic.template.annotation.PlatformSpecific;
 import dev.triassic.template.command.defaults.ReloadCommand;
+import dev.triassic.template.util.PlatformType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.incendo.cloud.CommandManager;
@@ -27,11 +29,31 @@ public final class CommandRegistry {
     /**
      * Registers all commands with the command manager.
      */
-    public void registerAll() {
+    public void registerAll(PlatformType platform) {
         final List<TemplateCommand> commands = List.of(
             new ReloadCommand(instance)
         );
 
-        commands.forEach(command -> command.register(commandManager));
+        commands.forEach(command -> {
+            if (isSupported(command.getClass(), platform)) {
+                command.register(commandManager);
+            } else {
+                System.out.println("Skipping " + command.getClass().getSimpleName()
+                    + " (not supported on " + platform + ")");
+            }
+        });
+    }
+
+    private static boolean isSupported(Class<?> clazz, PlatformType platform) {
+        PlatformSpecific annotation = clazz.getAnnotation(PlatformSpecific.class);
+        if (annotation == null) {
+            return true;
+        }
+        for (PlatformType allowed : annotation.value()) {
+            if (allowed == platform) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/core/src/main/java/dev/triassic/template/command/defaults/ReloadCommand.java
+++ b/core/src/main/java/dev/triassic/template/command/defaults/ReloadCommand.java
@@ -10,10 +10,12 @@
 package dev.triassic.template.command.defaults;
 
 import dev.triassic.template.TemplateImpl;
+import dev.triassic.template.annotation.PlatformSpecific;
 import dev.triassic.template.command.Commander;
 import dev.triassic.template.command.TemplateCommand;
 import dev.triassic.template.configuration.ConfigurationManager;
 import dev.triassic.template.configuration.TemplateConfiguration;
+import dev.triassic.template.util.PlatformType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -23,6 +25,7 @@ import org.slf4j.Logger;
 /**
  * A command that reloads the plugin's configuration.
  */
+@PlatformSpecific({PlatformType.BUKKIT, PlatformType.PAPER})
 public final class ReloadCommand extends TemplateCommand {
 
     private final Logger logger;

--- a/core/src/main/java/dev/triassic/template/configuration/TemplateConfiguration.java
+++ b/core/src/main/java/dev/triassic/template/configuration/TemplateConfiguration.java
@@ -9,6 +9,8 @@
 
 package dev.triassic.template.configuration;
 
+import dev.triassic.template.annotation.PlatformSpecific;
+import dev.triassic.template.util.PlatformType;
 import lombok.Getter;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
@@ -20,6 +22,10 @@ import org.spongepowered.configurate.objectmapping.meta.Comment;
 @ConfigSerializable
 @SuppressWarnings("FieldMayBeFinal")
 public class TemplateConfiguration {
+
+    @Comment("Should only appear on Bukkit-like platforms.")
+    @PlatformSpecific({PlatformType.BUKKIT, PlatformType.PAPER})
+    private String exampleString = "hello, bukkit!";
 
     /**
      * The version of the configuration file.


### PR DESCRIPTION
This pull request introduces a new `@PlatformSpecific(PlatformType[])` annotation to be used in the core module. This allows limiting specific configuration nodes or commands to specific platforms.