### PR TITLE
Add a @ExcludePlatform annotation to exclude platforms, closes #2

### DIFF
--- a/core/src/main/java/dev/triassic/template/TemplateImpl.java
+++ b/core/src/main/java/dev/triassic/template/TemplateImpl.java
@@ -53,14 +53,15 @@ public final class TemplateImpl {
         final long startTime = System.currentTimeMillis();
 
         try {
-            this.config = ConfigurationManager.load(dataDirectory, TemplateConfiguration.class);
+            this.config = ConfigurationManager.load(
+                dataDirectory, TemplateConfiguration.class, platformType);
         } catch (IOException e) {
             logger.error("Failed to load configuration", e);
             return;
         }
 
         this.commandRegistry = new CommandRegistry(this, commandManager);
-        commandRegistry.registerAll();
+        commandRegistry.registerAll(platformType);
 
         logger.info("Enabled in {}ms", System.currentTimeMillis() - startTime);
     }

--- a/core/src/main/java/dev/triassic/template/annotation/ExcludePlatform.java
+++ b/core/src/main/java/dev/triassic/template/annotation/ExcludePlatform.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: CC0-1.0
+ *
+ * Dedicated to the public domain under CC0 1.0 Universal.
+ *
+ * You can obtain a full copy of the license at:
+ *     https://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package dev.triassic.template.annotation;
+
+import dev.triassic.template.util.PlatformType;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Excludes a command class or configuration field from certain platforms.
+ *
+ * <p>Use this to prevent commands or config nodes from being registered or loaded
+ * on platforms where they are not supported. Elements without this annotation
+ * are included on all platforms by default.</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD})
+public @interface ExcludePlatform {
+
+    /**
+     * The platforms on which the annotated element should be excluded.
+     *
+     * @return an array of {@link PlatformType} to exclude
+     */
+    PlatformType[] value();
+}

--- a/core/src/main/java/dev/triassic/template/command/CommandRegistry.java
+++ b/core/src/main/java/dev/triassic/template/command/CommandRegistry.java
@@ -10,7 +10,10 @@
 package dev.triassic.template.command;
 
 import dev.triassic.template.TemplateImpl;
+import dev.triassic.template.annotation.ExcludePlatform;
 import dev.triassic.template.command.defaults.ReloadCommand;
+import dev.triassic.template.util.PlatformType;
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.incendo.cloud.CommandManager;
@@ -27,11 +30,21 @@ public final class CommandRegistry {
     /**
      * Registers all commands with the command manager.
      */
-    public void registerAll() {
+    public void registerAll(final PlatformType platformType) {
         final List<TemplateCommand> commands = List.of(
             new ReloadCommand(instance)
         );
 
-        commands.forEach(command -> command.register(commandManager));
+        commands.forEach(command -> {
+            final ExcludePlatform exclude = command.getClass().getAnnotation(ExcludePlatform.class);
+            if (exclude != null) {
+                if (Arrays.asList(exclude.value()).contains(platformType)) {
+                    return;
+                }
+            }
+
+            command.register(commandManager);
+        });
     }
+
 }

--- a/core/src/main/java/dev/triassic/template/command/defaults/ReloadCommand.java
+++ b/core/src/main/java/dev/triassic/template/command/defaults/ReloadCommand.java
@@ -10,10 +10,12 @@
 package dev.triassic.template.command.defaults;
 
 import dev.triassic.template.TemplateImpl;
+import dev.triassic.template.annotation.ExcludePlatform;
 import dev.triassic.template.command.Commander;
 import dev.triassic.template.command.TemplateCommand;
 import dev.triassic.template.configuration.ConfigurationManager;
 import dev.triassic.template.configuration.TemplateConfiguration;
+import dev.triassic.template.util.PlatformType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -23,6 +25,7 @@ import org.slf4j.Logger;
 /**
  * A command that reloads the plugin's configuration.
  */
+@ExcludePlatform({PlatformType.VELOCITY})
 public final class ReloadCommand extends TemplateCommand {
 
     private final Logger logger;

--- a/core/src/main/java/dev/triassic/template/command/defaults/ReloadCommand.java
+++ b/core/src/main/java/dev/triassic/template/command/defaults/ReloadCommand.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 /**
  * A command that reloads the plugin's configuration.
  */
-@ExcludePlatform({PlatformType.VELOCITY})
 public final class ReloadCommand extends TemplateCommand {
 
     private final Logger logger;

--- a/core/src/main/java/dev/triassic/template/configuration/TemplateConfiguration.java
+++ b/core/src/main/java/dev/triassic/template/configuration/TemplateConfiguration.java
@@ -9,6 +9,8 @@
 
 package dev.triassic.template.configuration;
 
+import dev.triassic.template.annotation.ExcludePlatform;
+import dev.triassic.template.util.PlatformType;
 import lombok.Getter;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
@@ -20,6 +22,17 @@ import org.spongepowered.configurate.objectmapping.meta.Comment;
 @ConfigSerializable
 @SuppressWarnings("FieldMayBeFinal")
 public class TemplateConfiguration {
+
+    /**
+     * An example string that showcases the usage of {@link ExcludePlatform}.
+     *
+     * <p>Take note of how the {@link ExcludePlatform} annotation goes after
+     * the {@link Comment} annotation, it is important to do it in this order,
+     * otherwise the node will be recreated empty to add the comment.</p>
+     */
+    @Comment("This string should not appear on Velocity and Bungeecord platforms.")
+    @ExcludePlatform({PlatformType.BUNGEECORD, PlatformType.VELOCITY})
+    private String exampleString = "This is an example string!";
 
     /**
      * The version of the configuration file.


### PR DESCRIPTION
Used for excluding specific platforms from registering specific commands or writing specific configuration nodes, supercedes #2 as excluding platforms makes more sense for our use case rather than including.